### PR TITLE
Prefetch API requests after homepage is loaded

### DIFF
--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -1,12 +1,22 @@
 import { Button, Paper } from '@mantine/core';
+import { useEffect } from 'react';
 import { BsInstagram, BsTwitterX, BsYoutube } from 'react-icons/bs';
 import { ImFacebook2 } from 'react-icons/im';
+import { moviesApiSlice } from '../../features/moviesApiSlice';
 import './Homepage.scss';
 import LastReviews from './LastReviews/LastReviews';
 import NewsFeed from './NewsFeed/NewsFeed';
 import PosterCarousel from './PosterCarousel/PosterCarousel';
 
 function Homepage() {
+  const prefetchMovies = moviesApiSlice.usePrefetch('getMoviesByFilter');
+  const prefetchMovieList = moviesApiSlice.usePrefetch('getMoviesByParams');
+
+  useEffect(() => {
+    prefetchMovies('nowplaying');
+    prefetchMovieList({ page: 1, sort_by: 'popularity.desc' });
+  }, [prefetchMovies, prefetchMovieList]);
+
   return (
     <div className="homepage">
       <div className="hero">

--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -14,7 +14,7 @@ function Homepage() {
 
   useEffect(() => {
     prefetchMovies('nowplaying');
-    prefetchMovieList({ page: 1, sort_by: 'popularity.desc' });
+    prefetchMovieList({ page: 1, sort_by: 'popularity.desc', with_genres: '' });
   }, [prefetchMovies, prefetchMovieList]);
 
   return (


### PR DESCRIPTION
To improve UX and reduce loading times, when user opens homepage it will automatically :
- Prefetch 'nowplaying' and 'popularity' lists.
- Prefetch requests for each movie of 'nowplaying' and 'upcoming' lists.

ℹ️ using [RTK Query prefetch](https://redux-toolkit.js.org/rtk-query/usage/prefetching)