### PR TITLE
Fix: invalidate user data in RTK Query after user logout

### DIFF
--- a/src/store/logout.middleware.ts
+++ b/src/store/logout.middleware.ts
@@ -1,0 +1,16 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit';
+import { moviesApiSlice } from '../features/moviesApiSlice';
+import { playlistApiSlice } from '../features/playlistApiSlice';
+import { logout } from '../features/settingsSlice';
+
+export const logoutListener = createListenerMiddleware();
+
+// This listener will invalidate the cache for the MovieUserdata
+// and Playlists tags when the logout action is dispatched
+logoutListener.startListening({
+  actionCreator: logout,
+  effect: async (_action, listenerApi) => {
+    listenerApi.dispatch(moviesApiSlice.util.invalidateTags(['MovieUserdata']));
+    listenerApi.dispatch(playlistApiSlice.util.invalidateTags(['Playlists']));
+  },
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,13 +2,15 @@ import { configureStore } from '@reduxjs/toolkit';
 import { axiosInterceptor } from '../apiHandler/api';
 import apiSlice from '../apiHandler/apiSlice';
 import settingsReducer from '../features/settingsSlice';
+import { logoutListener } from './logout.middleware';
 
 const store = configureStore({
   reducer: {
     settings: settingsReducer,
     [apiSlice.reducerPath]: apiSlice.reducer,
   },
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(apiSlice.middleware),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().prepend(logoutListener.middleware).concat(apiSlice.middleware),
   devTools: true,
 });
 


### PR DESCRIPTION
Adds a redux middleware to invalidate user data cache when user is logged out.
- https://redux-toolkit.js.org/api/createListenerMiddleware
- https://redux-toolkit.js.org/rtk-query/internal/buildMiddleware/invalidationByTags

Common use case : a user logout then relog with other credentials. User data from previous user must not be used for next user.

fixes #6 